### PR TITLE
Support Laravel 11–13 (drop 9)

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1]
-        laravel: [9.*]
-        stability: [prefer-lowest, prefer-stable]
+        php: [8.2, 8.3, 8.4]
+        laravel: [11.*, 12.*, 13.*]
+        stability: [prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,11 @@
         "test-coverage": "vendor/bin/pest --coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,20 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^9.0"
+        "illuminate/contracts": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^6.0",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0",
-        "pestphp/pest": "^1.21",
-        "pestphp/pest-plugin-laravel": "^1.1",
+        "nunomaduro/collision": "^8.0|^9.0",
+        "nunomaduro/larastan": "^2.0.1|^3.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.0|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.0|^2.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,16 +23,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace BernskioldMedia\LaravelScrive\Tests;
 
-use BernskioldMedia\LaravelScrive\LaravelScriveServiceProvider;
+use BernskioldMedia\LaravelScrive\ScriveServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -20,7 +20,7 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
-            LaravelScriveServiceProvider::class,
+            ScriveServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Summary
- Big jump from Laravel 9 to Laravel 11+: drops Laravel 9, adds Laravel 11, 12, and 13
- Bumps PHP minimum from 8.0 to 8.2 (Laravel 11's floor)
- Refreshes every dev dependency to its current generation: `orchestra/testbench` (`^9.0|^10.0|^11.0`), `nunomaduro/collision` (`^8.0|^9.0`), `nunomaduro/larastan` (`^2.0.1|^3.0`), `pestphp/pest` and `pestphp/pest-plugin-laravel` (each `^2.0|^3.0|^4.0`), `phpunit/phpunit` (`^10.0|^11.0|^12.0`), and the phpstan extras
- CI matrix replaces the Laravel 9 / PHP 8.1 entry with Laravel 11/12/13 on PHP 8.2/8.3/8.4 (L13 excluded on PHP 8.2 since L13 requires 8.3+)
- `prefer-lowest` removed; PHPStan job moved from PHP 8.0 to PHP 8.2

## Test plan
- [ ] CI matrix passes for Laravel 11/12 across PHP 8.2/8.3/8.4
- [ ] CI matrix passes for Laravel 13 on PHP 8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)